### PR TITLE
Move Syntect support into Markdown crate

### DIFF
--- a/lx/.nova/Configuration.json
+++ b/lx/.nova/Configuration.json
@@ -1,0 +1,3 @@
+{
+  "workspace.color" : 2
+}

--- a/lx/crates/markdown/bin/lx-md.rs
+++ b/lx/crates/markdown/bin/lx-md.rs
@@ -10,7 +10,7 @@ use clap_complete::{generate_to, shells::Fish};
 use serde_yaml::{self, Value};
 use thiserror::Error;
 
-use lx_md::render;
+use lx_md::Markdown;
 
 fn main() -> Result<()> {
    use Command::*;
@@ -35,7 +35,9 @@ fn main() -> Result<()> {
       .read_to_string(&mut s)
       .map_err(|source| Error::ReadToString { source })?;
 
-   let (meta, rendered) = render(&s, None, &mut |s| s.to_owned()).map_err(Error::from)?;
+   let (meta, rendered) = Markdown::new()
+      .render(&s, |s| s.to_string())
+      .map_err(Error::from)?;
 
    let metadata = match (cli.include_metadata, meta) {
       (true, Some(metadata)) => yaml_to_table(&metadata)?,

--- a/lx/crates/markdown/src/second_pass.rs
+++ b/lx/crates/markdown/src/second_pass.rs
@@ -14,7 +14,7 @@ use super::FootnoteDefinitions;
 /// 3. Performing any template-language-type rewriting of text nodes.
 struct State<'e, 's> {
    footnote_definitions: FootnoteDefinitions<'e>,
-   syntax_set: Option<&'s SyntaxSet>,
+   syntax_set: &'s SyntaxSet,
    code_block: Option<CodeBlock<'e, 's>>,
    events: Vec<pulldown_cmark::Event<'e>>,
    emitted_definitions: Vec<(CowStr<'e>, Vec<pulldown_cmark::Event<'e>>)>,
@@ -40,7 +40,7 @@ pub enum Error {
 
 pub(super) fn second_pass<'e>(
    footnote_definitions: FootnoteDefinitions<'e>,
-   syntax_set: Option<&SyntaxSet>,
+   syntax_set: &SyntaxSet,
    events: Vec<first_pass::Event<'e>>,
    rewrite: impl Fn(&str) -> String,
 ) -> Result<impl Iterator<Item = pulldown_cmark::Event<'e>>, Error> {
@@ -211,15 +211,7 @@ struct CodeBlock<'e, 's> {
 
 impl<'c, 's> CodeBlock<'c, 's> {
    /// Start highlighting a code block.
-   fn start(kind: CodeBlockKind, syntax_set: Option<&'s SyntaxSet>) -> Self {
-      let Some(syntax_set) = syntax_set else {
-         let html = pulldown_cmark::Event::Html("<pre><code>".into());
-         return CodeBlock { highlighting: Highlighting::UnknownSyntax,
-            syntax_set: None,
-            events: vec![html],
-          };
-      };
-
+   fn start(kind: CodeBlockKind, syntax_set: &'s SyntaxSet) -> Self {
       match kind {
          CodeBlockKind::Fenced(name) => {
             let found = syntax_set.find_syntax_by_token(name.as_ref());

--- a/lx/src/metadata/mod.rs
+++ b/lx/src/metadata/mod.rs
@@ -7,6 +7,7 @@ use std::path::StripPrefixError;
 
 use chrono::DateTime;
 use chrono::FixedOffset;
+use lx_md::Markdown;
 use serde_derive::Serialize;
 use slug::slugify;
 use syntect::parsing::SyntaxSet;
@@ -59,7 +60,7 @@ impl Metadata {
       root_dir: &Path,
       cascade: &Cascade,
       default_template_name: String,
-      syntax_set: &SyntaxSet,
+      md: &Markdown,
    ) -> Result<Self, Error> {
       let permalink: Option<PathBuf> = item.permalink.map(|permalink| {
          permalink
@@ -80,7 +81,7 @@ impl Metadata {
                source: Some(e),
             })?;
 
-      let render = |s: String| Rendered::as_markdown(&s, Some(syntax_set));
+      let render = |s: String| Rendered::as_markdown(&s, md);
 
       let updated = item.updated.into_iter().try_fold(
          Vec::new(),
@@ -132,8 +133,8 @@ impl Metadata {
 pub struct Rendered(String);
 
 impl Rendered {
-   fn as_markdown(src: &str, syntax_set: Option<&SyntaxSet>) -> Result<Rendered, Error> {
-      lx_md::render(src, syntax_set, |s| s.to_string())
+   fn as_markdown(src: &str, md: &Markdown) -> Result<Rendered, Error> {
+      md.render(src, |s| s.to_string())
          .map(|(_, rendered)| Rendered(rendered.html()))
          .map_err(Error::from)
    }


### PR DESCRIPTION
- Update the entry point to expose a `Markdown` struct which will manage the state, i.e. the syntax definition and the pass.

- Move the Syntect initialization (or not!) into the creation of that new struct.

This makes it so both `lx-md` and `lx` can just use the same underlying implementation, which is great! Also simplifies the call stack a *lot*.

Resolves #17. (Not by implementing it, though!)