### PR TITLE
Use Syntect built-in SyntaxSet

### DIFF
--- a/lx/crates/markdown/src/lib.rs
+++ b/lx/crates/markdown/src/lib.rs
@@ -273,11 +273,12 @@ fn load_syntaxes() -> SyntaxSet {
    // let mut extra_syntaxes_dir = std::env::current_dir().map_err(|e| format!("{}", e))?;
    // extra_syntaxes_dir.push("syntaxes");
 
-   let syntax_builder = SyntaxSet::load_defaults_newlines().into_builder();
+   // let syntax_builder = SyntaxSet::load_defaults_newlines().into_builder();
    // let mut syntax_builder = SyntaxSet::load_defaults_newlines().into_builder();
    // syntax_builder
    //     .add_from_folder(&extra_syntaxes_dir, false)
    //     .map_err(|e| format!("could not load {}: {}", &extra_syntaxes_dir.display(), e))?;
 
-   syntax_builder.build()
+   // syntax_builder.build()
+   SyntaxSet::load_defaults_newlines()
 }


### PR DESCRIPTION
This takes the time for rendering the 'jj init' post from 136ms down to 20ms. This is *not* the final approach I want to take, because I ultimately want to bake in my own syntaxes. Probably, anyway: I do not think Syntect ships with *everything* I want, but I do not actually know that for sure; I will have to check! In any case, this handily solves the perf issue for the moment.