### PR TITLE
build: use musl for Linux release build

### DIFF
--- a/.github/workflows/CI and CD.yml
+++ b/.github/workflows/CI and CD.yml
@@ -78,12 +78,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: x86_64-unknown-linux-musl
 
       - name: Create release build
         run: cargo build --locked --release
 
       - name: Confirm release results
-        run: ls -l target/release/lx
+        run: |
+          ls -l target/release/lx
+          mv target/release/lx ../lx-linux-musl
 
       - name: Generate Release Name
         id: release_name
@@ -93,7 +97,7 @@ jobs:
 
       - uses: softprops/action-gh-release@v2
         with:
-          files: lx/target/release/lx
+          files: lx-linux-musl
           fail_on_unmatched_files: true
           name: ${{ steps.release_name.outputs.release_name }}
           tag_name: ${{ steps.release_name.outputs.release_name }}

--- a/_scripts/build.sh
+++ b/_scripts/build.sh
@@ -7,7 +7,7 @@ set -o errexit -o nounset -o pipefail
 IFS=$'\n\t'
 
 RELEASES="https://github.com/chriskrycho/v6.chriskrycho.com/releases"
-LATEST="${RELEASES}/latest/download/lx"
+LATEST="${RELEASES}/latest/download/lx-linux-musl"
 OUTPUT="lx-cli"
 rm -f $OUTPUT
 
@@ -28,7 +28,7 @@ download_for_pr() {
   local sha
   sha=$(git rev-parse --short HEAD)
 
-  local pr="${RELEASES}/download/lx-${sha}/lx"
+  local pr="${RELEASES}/download/lx-${sha}/lx-linux-musl"
 
   local pr_result
   pr_result=$(download "$pr" "$OUTPUT")


### PR DESCRIPTION
To avoid the dreaded “wrong GLIBC version”.