### PR TITLE
build: support Render previews given its limitations

### DIFF
--- a/.github/workflows/CI and CD.yml
+++ b/.github/workflows/CI and CD.yml
@@ -60,11 +60,7 @@ jobs:
   release:
     name: Create and upload release
     needs: [check]
-    if: ${{
-      github.event.push.commits.author.username == 'chriskrycho' ||
-      github.event.pull_request.user.login == 'chriskrycho' ||
-      github.actor == 'chriskrycho'
-      }}
+    if: ${{ github.event.push.commits.author.username == 'chriskrycho' && github.ref == 'refs/heads/main'}}
     permissions:
       contents: write
     runs-on: ubuntu-22.04
@@ -74,10 +70,11 @@ jobs:
       - name: Create release build
         run: cargo build --locked --release
 
-      - name: Confirm release results
-        run: |
-          ls -l target/release/lx
-          mv target/release/lx lx-linux
+      - name: Show release build info
+        run: ls -l target/release/lx
+
+      - name: Rename and move release binary
+        run: mv target/release/lx lx-linux
 
       - name: Generate Release Name
         id: release_name
@@ -91,7 +88,6 @@ jobs:
           fail_on_unmatched_files: true
           name: ${{ steps.release_name.outputs.release_name }}
           tag_name: ${{ steps.release_name.outputs.release_name }}
-          prerelease: ${{ github.event_name == 'pull_request' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -125,10 +121,10 @@ jobs:
   trigger-deploy-music:
     needs: [changes, build-check]
     if: ${{
-      ((needs.changes.outputs.music == 'true' || needs.changes.outputs.cfg == 'true' || github.event_name == 'workflow_dispatch')
-      && needs.build-check.outputs.state == 'non-needed'
-      )
-      || needs.build-check.outputs.state == 'succeeded'
+      github.ref == 'refs/heads/main' &&
+      (((needs.changes.outputs.music == 'true' || needs.changes.outputs.cfg == 'true' || github.event_name == 'workflow_dispatch')
+      && needs.build-check.outputs.state == 'non-needed')
+      || needs.build-check.outputs.state == 'succeeded')
       }}
     runs-on: ubuntu-22.04
     steps:
@@ -136,19 +132,15 @@ jobs:
       - name: Render deploy hook
         env:
           deploy_url: ${{ secrets.RENDER_DEPLOY_HOOK_MUSIC }}
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            SHA=$(git rev-parse --short HEAD)
-            deploy_url="${deploy_url}&ref=${SHA}"
-          fi
-          curl "$deploy_url"
+        run: curl "$deploy_url"
 
   trigger-deploy-v6:
     needs: [changes, build-check]
     if: ${{
-      ((needs.changes.outputs.v6 == 'true' || needs.changes.outputs.cfg == 'true' || github.event_name == 'workflow_dispatch')
+      github.ref == 'refs/heads/main' &&
+      (((needs.changes.outputs.v6 == 'true' || needs.changes.outputs.cfg == 'true' || github.event_name == 'workflow_dispatch')
       && needs.build-check.outputs.state == 'non-needed')
-      || needs.build-check.outputs.state == 'succeeded'
+      || needs.build-check.outputs.state == 'succeeded')
       }}
     runs-on: ubuntu-22.04
     steps:
@@ -156,9 +148,4 @@ jobs:
       - name: Render deploy hook
         env:
           deploy_url: ${{ secrets.RENDER_DEPLOY_HOOK_V6 }}
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            SHA=$(git rev-parse --short HEAD)
-            deploy_url="${deploy_url}&ref=${SHA}"
-          fi
-          curl "$deploy_url"
+        run: curl "$deploy_url"

--- a/_scripts/build.sh
+++ b/_scripts/build.sh
@@ -22,41 +22,13 @@ LATEST="${RELEASES}/latest/download/lx-linux"
 OUTPUT="lx-cli"
 rm -f $OUTPUT
 
-download() {
-  local url="$1"
-  local output="$2"
-
-  echo "fetching '$url' to '$output'"
-
-  curl --location \
+echo "fetching '$LATEST' to '$OUTPUT'"
+curl --location \
     --proto '=https' --tlsv1.2 \
     --silent --show-error --fail \
-    --output "$output" \
-    "$url"
-}
-
-# Note for jj usage (read: local testing): make sure the repo is colocated!
-download_for_pr() {
-  local sha
-  sha=$(git rev-parse --short HEAD)
-
-  local pr="${RELEASES}/download/lx-${sha}/lx-linux"
-
-  local pr_result
-  pr_result=$(download "$pr" "$OUTPUT")
-
-  local pr_exit=$?;
-  echo "PR: $pr_exit $pr_result"
-
-  if [[ "$pr_exit" -ne 0 ]]; then
-    echo "falling back to latest: $LATEST"
-    download $LATEST $OUTPUT
-  fi
-}
-
-# This works regardless of whether Render understands that a given deploy hook
-# was triggered by a pull request or not.
-download_for_pr || exit $?
+    --output "$OUTPUT" \
+    "$LATEST" \
+  || exit $?
 
 chmod +x $OUTPUT
 

--- a/render.yaml
+++ b/render.yaml
@@ -23,6 +23,7 @@ services:
       paths:
         - site/styles/**
         - sites/music/**
+        - sites/_shared/**
     buildCommand: |
       bash ./_scripts/build.sh music
 


### PR DESCRIPTION
I am changing my assumptions, after much thinking about how to wrangle this at some length.

1. I will not try to do preview changes for `lx` on Render.
2. I can therefore have Render always use the *latest* build of `lx`, rather than mucking around with specific versions.
3. I will thus only deploy new builds of `lx` from `main`.
4. I still need to avoid “auto-deploying”, so that I only deploy once a release has been created, for the cases where I have made changes to `lx` that might break existing templates.

Net, then, I need to only trigger a deploy on `main` (while keeping the existing rules in place, too), and on the build script side just always use the latest version, not mucking around with PR versions.